### PR TITLE
Create Rstudio project and remove unlist() call

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,2 @@
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata
+src/*.o
+src/*.so
+src/*.dll

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,4 +9,5 @@ LazyLoad: yes
 Collate: classes.R COMLists.S  COMError.R com.R debug.S zzz.R runTime.S
 URL:  http://www.omegahat.net/RDCOMClient,  http://www.omegahat.net
       http://www.omegahat.net/bugs
-
+Depends:
+    R (>= 3.2.0)

--- a/RDCOMClient.Rproj
+++ b/RDCOMClient.Rproj
@@ -1,0 +1,17 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source

--- a/src/converters.cpp
+++ b/src/converters.cpp
@@ -139,16 +139,7 @@ getArray(SAFEARRAY *arr, int dimNo, int numDims, long *indices)
     }
     SET_VECTOR_ELT(ans, i, el);
   }
-  if(numDims == 1 && rtype != -1) {
-    switch(rtype) {
-      case INTSXP:
-      case LGLSXP:
-      case REALSXP:
-      case STRSXP:
-	ans = UnList(ans);
-	break;
-    }
-  }
+
   UNPROTECT(1);
 
   return(ans);


### PR DESCRIPTION
The first commit is fairly minor, but creates an Rstudio package project. I find that this makes managing packages a lot easier, and it is how many popular packages are handled (e.g. https://github.com/tidyverse/dplyr).

The second commit does change the behavior of the underlying C. If the following array was coming back over COM:

`{ {1, 2}, {3, 4} }`

It was being flattened to a single vector like:

`c(1:4)`

I'm sure a different solution exists. Maybe some correction to `numDims`. On the other hand, I still think removal is the best way forward. Removing it all together makes the package a lot more consistent; you always get a list back. If you leave it in (or some improved version), you'll sometimes get a vector back. This complication isn't desirable IMO.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bschamberger/rdcomclient/2)
<!-- Reviewable:end -->
