### PR TITLE
add definitions of internal macros that are missing since R 4.2

### DIFF
--- a/src/RCOMObject.h
+++ b/src/RCOMObject.h
@@ -40,6 +40,8 @@ extern "C" {
   extern void R_ReleaseObject(SEXP);
 }
 
+#include "compat.h"
+
 #ifdef length
 #undef length
 #endif

--- a/src/RUtils.c
+++ b/src/RUtils.c
@@ -1,6 +1,8 @@
 #include <RUtils.h>
 #include <R_ext/Rdynload.h>
 
+#include "compat.h"
+
 static SEXP R_IDispatchSym, R_IUnknownSym, R_ITypeLibSym;
 
 void

--- a/src/compat.h
+++ b/src/compat.h
@@ -1,0 +1,21 @@
+#ifndef COMPAT_H
+#define COMPAT_H
+
+#ifndef R_PROBLEM_BUFSIZE
+
+// copied from RS.h of R 4.1
+
+#define R_PROBLEM_BUFSIZE	4096
+/* Parentheses added for FC4 with gcc4 and -D_FORTIFY_SOURCE=2 */
+#define PROBLEM			{char R_problem_buf[R_PROBLEM_BUFSIZE];(snprintf)(R_problem_buf, R_PROBLEM_BUFSIZE,
+#define MESSAGE                 {char R_problem_buf[R_PROBLEM_BUFSIZE];(snprintf)(R_problem_buf, R_PROBLEM_BUFSIZE,
+#define ERROR			),Rf_error(R_problem_buf);}
+#define RECOVER(x)		),Rf_error(R_problem_buf);}
+#define WARNING(x)		),Rf_warning(R_problem_buf);}
+#define LOCAL_EVALUATOR		/**/
+#define NULL_ENTRY		/**/
+#define WARN			WARNING(NULL)
+
+#endif
+
+#endif

--- a/src/connect.cpp
+++ b/src/connect.cpp
@@ -23,7 +23,7 @@ extern "C" {
 }
 
 
-
+#include "compat.h"
 #include "converters.h"
 
 


### PR DESCRIPTION
Hello,

I have been using your fork for `RDCOMClient`  a while because of its various fixes. However, I noticed the package doesn't compile with R 4.2, as it seems that some internal macros used (`PROBLEM`, `WARN`, ...) are not defined anymore. In this PR I simply copied them back a to a new header file. 